### PR TITLE
Add setup script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ This repository contains the React front end and Supabase Edge Functions for Fam
 
 ## Setup
 
-1. Install dependencies:
+1. Install dependencies **before running any npm script**:
    ```bash
    npm install
    ```
+   You can also run `./setup.sh` to install dependencies automatically.
 2. Copy the example environment file and provide your own values:
    ```bash
    cp .env.example .env
@@ -34,6 +35,8 @@ When running or deploying functions from the `supabase/functions` directory the 
 - `GEMINI_API_KEY` – Gemini API key used by server functions
 
 ## Commands
+
+Before running `npm run lint`, `npm run build`, or any other npm script, make sure dependencies have been installed with `npm install` (or by running `./setup.sh`).
 
 ### React app
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+npm install


### PR DESCRIPTION
## Summary
- mention `npm install` requirement for npm scripts in README
- note optional `setup.sh` helper script
- add `setup.sh` script

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68496f37a3a48320a171a9a57c164fb3