### PR TITLE
Refactor AppContext structure

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
-import { AppProvider } from './context/AppContext';
+import AppProvider from './context/AppContext.jsx';
 import ProtectedRoute from './components/ProtectedRoute';
 
 // Layouts

--- a/src/context/AppContext.js
+++ b/src/context/AppContext.js
@@ -1,0 +1,6 @@
+import { createContext, useContext } from 'react';
+
+export const AppContext = createContext();
+
+export const useAppContext = () => useContext(AppContext);
+

--- a/src/context/AppContext.jsx
+++ b/src/context/AppContext.jsx
@@ -1,13 +1,8 @@
-import { createContext, useState, useContext } from 'react';
-
-// Context to hold application state
-const AppContext = createContext();
-
-// Hook for accessing the context
-export const useAppContext = () => useContext(AppContext);
+import { useState } from 'react';
+import { AppContext } from './AppContext.js';
 
 // Provider component that wraps the application
-export const AppProvider = ({ children }) => {
+const AppProvider = ({ children }) => {
   // mealPlan state removed in favor of database usage
   const [shoppingList, setShoppingList] = useState({});
 
@@ -23,3 +18,5 @@ export const AppProvider = ({ children }) => {
     </AppContext.Provider>
   );
 };
+
+export default AppProvider;

--- a/src/pages/ShoppingListPage.jsx
+++ b/src/pages/ShoppingListPage.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
-import { useAppContext } from '../context/AppContext';
+import { useAppContext } from '../context/AppContext.js';
 
 export default function ShoppingListPage() {
   const { shoppingList, setShoppingList } = useAppContext();


### PR DESCRIPTION
## Summary
- split context creation into `AppContext.js`
- keep `AppProvider` as default export in `AppContext.jsx`
- update imports for new module structure

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684978017e80832094977d241ba81aee