### PR TITLE
Add DB reset instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,19 @@ supabase functions deploy generate-meal-plan
 supabase functions deploy generate-shopping-list
 supabase functions deploy invite-member
 ```
+
+### Reset the database
+
+The SQL script at `supabase/sql/reset-schema.sql` drops any existing tables and
+recreates them with all constraints, triggers, and RLS policies. Run it whenever
+you need a fresh local database.
+
+Using the Supabase CLI:
+```bash
+supabase db execute supabase/sql/reset-schema.sql
+```
+
+Or with `psql`:
+```bash
+psql "$SUPABASE_DB_URL" -f supabase/sql/reset-schema.sql
+```


### PR DESCRIPTION
## Summary
- document how to run `supabase/sql/reset-schema.sql` via Supabase CLI or psql

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849798c626c83208c54c84dc8b99754