### PR TITLE
Fix new user trigger metadata fallback

### DIFF
--- a/supabase/sql/reset-schema.sql
+++ b/supabase/sql/reset-schema.sql
@@ -99,9 +99,11 @@ SET search_path = public
 AS $$
 BEGIN
   INSERT INTO public.profiles(id, full_name, role)
-  VALUES (NEW.id,
-          NEW.raw_user_meta_data->>'full_name',
-          NEW.raw_user_meta_data->>'role');
+  VALUES (
+      NEW.id,
+      coalesce(NEW.raw_user_meta_data->>'full_name', NEW.user_metadata->>'full_name'),
+      coalesce(NEW.raw_user_meta_data->>'role', NEW.user_metadata->>'role')
+  );
   RETURN NEW;
 END;
 $$;


### PR DESCRIPTION
## Summary
- update `handle_new_user()` in `reset-schema.sql` to fall back to `user_metadata`
- keep trigger in place for user sign-ups

## Testing
- `npm run lint`
- `npx supabase db execute supabase/sql/reset-schema.sql` *(fails: "Use \"supabase db [command] --help\" for more information")*

------
https://chatgpt.com/codex/tasks/task_e_68497e7846948320a0bc54a2f657726d